### PR TITLE
Add alternative method for getting message body

### DIFF
--- a/app/src/main/java/dev/altavision/pnrgatewayclient/PDUReceiver.java
+++ b/app/src/main/java/dev/altavision/pnrgatewayclient/PDUReceiver.java
@@ -12,6 +12,8 @@ import android.widget.Toast;
 
 import androidx.preference.PreferenceManager;
 
+import java.nio.charset.StandardCharsets;
+
 public class PDUReceiver extends BroadcastReceiver {
     private SharedPreferences mPrefs = null;
 
@@ -47,6 +49,14 @@ public class PDUReceiver extends BroadcastReceiver {
                 //messageBody will include the REG-RESP text--i.e.
                 //  REG-RESP?v=3;r=72325403;n=+11234567890;s=CA21C50C645469B25F4B65C38A7DCEC56592E038F39489F35C7CD6972D
                 String messageBody = recMsg.getMessageBody();
+
+                //On some carriers, the PDU received is not readable by the default Android functions.
+                //This results in the message body being null despite receiving the data
+                if (messageBody == null) {
+                    messageBody = new String((byte[]) pdus[i], StandardCharsets.US_ASCII);
+                    int startIndex = messageBody.indexOf("REG-RESP");
+                    messageBody = messageBody.substring(startIndex);
+                }
 
                 //Hands the REG-RESP message off to the SMSReceiver to notify the user
                 SMSReceiver.processResponseMessage(messageBody, context);


### PR DESCRIPTION
In my case, the messageBody ended up being _null_ in the received PDU. Further investigation showed that I was receiving a PDU with the needed data, just not in the format that Android seemed to expect. This is fixed by simply converting the raw byte array to an ASCII string and searching for the REG-RESP text in it. This was on LTE Verizon network using a Pixel 3a running LineageOS 19 (which is built from Android 12). Currently unknown whether this was an issue caused by the OS or by Verizon.